### PR TITLE
create .stylelintignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+.lostpixel/
+storybook-static/


### PR DESCRIPTION
Create `.styleignore`. 

The way that `lost-pixel` works is that it automatically creates a PR in CI to update baseline images, which are committed to the repo.

CI for `lost-pixel` fails because `stylelint` is trying to lint files related to the `create-pull-request` action.